### PR TITLE
move to js file

### DIFF
--- a/src/public/index.ejs
+++ b/src/public/index.ejs
@@ -618,7 +618,7 @@ public class Example {
 
         function loadSocket(){
             socket.on("record", ({recordCount, recordSize}) => {
-                fileCountSpan.innerText = recordCount;
+                fileCountSpan.innerText = recordCount.toLocaleString();
                 totalFileSizeSpan.innerText = recordSize;
             });
         }

--- a/src/services/socket/recordInfoSocket.ts
+++ b/src/services/socket/recordInfoSocket.ts
@@ -22,10 +22,10 @@ export class RecordInfoSocket {
     }
 
     private async getPayload(): Promise<RecordInfoPayload> {
-        const records = await this.repo.getRecordCount();
+        const recordCount = await this.repo.getRecordCount();
         const size = (await this.repo.getTotalFileSize()) ?? 0;
         return {
-            recordCount: records.toLocaleString(),
+            recordCount,
             recordSize: ObjectUtils.sizeToHuman(size),
         };
     }

--- a/src/utils/typeings.ts
+++ b/src/utils/typeings.ts
@@ -58,6 +58,6 @@ export type ProtectionLevel = "Encrypted" | "Password" | "None";
 export type Awaitable<T> = Promise<T> | T;
 
 export type RecordInfoPayload = {
-    recordCount: string;
+    recordCount: number;
     recordSize: string;
 };


### PR DESCRIPTION
`toLocaleString` returns a localised formatted string of a number. doing this on the server means that it will always be formatted to `EN-GB` and never to the local browser. so this should be moved to the browser