### PR TITLE
more modify entry fixes

### DIFF
--- a/src/model/dto/EntryModificationDto.ts
+++ b/src/model/dto/EntryModificationDto.ts
@@ -1,6 +1,6 @@
 import { Description, Optional, Property } from "@tsed/schema";
-import { BeforeDeserialize } from "@tsed/json-mapper";
 import { BadRequest } from "@tsed/exceptions";
+import { BeforeDeserialize } from "@tsed/json-mapper";
 
 @BeforeDeserialize((data: Record<keyof EntryModificationDto, unknown>) => {
     if (data.customExpiry) {
@@ -18,7 +18,9 @@ import { BadRequest } from "@tsed/exceptions";
 export class EntryModificationDto {
     @Property()
     @Optional()
-    @Description("Set/change the password. If changing a password, then `previousPassword` must be set")
+    @Description(
+        'Set/change the password. If changing a password, then `previousPassword` must be set. leave as empty string "" to remove the password',
+    )
     public password?: string;
 
     @Property()
@@ -29,7 +31,7 @@ export class EntryModificationDto {
     @Property()
     @Description(
         "a string containing a number and a letter of `m` for mins, `h` for hours, `d` for days. For example: `1h` would be 1 hour and `1d` would be 1 day. " +
-            "leave this blank if you want the file to exist according to the retention policy. " +
+            "make this an empty string to reset the expiry back to defaults. " +
             "NOTE: the file expiry will be recalculated from the moment you change this value, not the time it was uploaded (the standard retention rate limit still has effect).",
     )
     @Optional()

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -118,8 +118,8 @@ export class FileUtils {
         return ttl < FileUtils.MIN_EXPIRATION ? FileUtils.MIN_EXPIRATION : ttl;
     }
 
-    public static getExpiresBySize(filesize: number): number {
-        return Date.now() + this.getTimeLeftBySize(filesize);
+    public static getExpiresBySize(filesize: number, dateToUse = Date.now()): number {
+        return dateToUse + this.getTimeLeftBySize(filesize);
     }
 
     public static async getFilesCount(): Promise<number> {
@@ -136,7 +136,7 @@ export class FileUtils {
         return fs.rm(toDelete, { recursive: true, force });
     }
 
-    public static async getFileSize(file: string | PlatformMulterFile): Promise<number> {
+    public static async getFileSize(file: string | PlatformMulterFile | FileUploadModel): Promise<number> {
         const f = this.getFilePath(file);
         const stat = await fs.stat(f);
         return stat.size;


### PR DESCRIPTION
fixed verious issues.

the rule is, if you want to "unset" a prop like custom expiry or password, it must be in the payload as a blank string `""`