### PR TITLE
Fix emit when used during filecleaner at startup

### DIFF
--- a/src/services/FileCleaner.ts
+++ b/src/services/FileCleaner.ts
@@ -1,4 +1,5 @@
-import { Constant, Inject, type OnInit, Service } from "@tsed/di";
+import { Constant, Inject, Service } from "@tsed/di";
+import { OnReady } from "@tsed/common";
 import { FileRepo } from "../db/repo/FileRepo.js";
 import { ScheduleService } from "./ScheduleService.js";
 import { FileService } from "./FileService.js";
@@ -8,7 +9,7 @@ import fs from "node:fs/promises";
 import { FileUploadModel } from "../model/db/FileUpload.model.js";
 
 @Service()
-export class FileCleaner implements OnInit {
+export class FileCleaner implements OnReady {
     public constructor(
         @Inject() private repo: FileRepo,
         @Inject() private scheduleService: ScheduleService,
@@ -31,7 +32,7 @@ export class FileCleaner implements OnInit {
         await this.fileUploadService.processDelete(expiredTokens);
     }
 
-    public $onInit(): void {
+    public $onReady(): void {
         this.scheduleService.scheduleCronJob(
             this.cronToRun,
             async () => {

--- a/src/services/socket/RecordInfoSocket.ts
+++ b/src/services/socket/RecordInfoSocket.ts
@@ -14,7 +14,7 @@ export class RecordInfoSocket {
 
     public async emit(): Promise<boolean> {
         const payload = await this.getPayload();
-        return this.nsp.emit("record", payload);
+        return this.nsp?.emit("record", payload);
     }
 
     public async $onConnection(): Promise<void> {

--- a/src/services/socket/RecordInfoSocket.ts
+++ b/src/services/socket/RecordInfoSocket.ts
@@ -14,7 +14,7 @@ export class RecordInfoSocket {
 
     public async emit(): Promise<boolean> {
         const payload = await this.getPayload();
-        return this.nsp?.emit("record", payload);
+        return this.nsp.emit("record", payload);
     }
 
     public async $onConnection(): Promise<void> {


### PR DESCRIPTION
When the server is first started, and the file cleaner has not ran, it can be run before the socket is initialized.
At first run this causes the server to crash.
![Screen Shot 2024-03-22 at 3 48 05 PM](https://github.com/waifuvault/WaifuVault/assets/133156975/81174113-d529-4f8a-b80c-efa5a19dc1e5)
