### PR TITLE
Remove redundant file cleanup

### DIFF
--- a/src/controllers/rest/impl/FileUploadController.ts
+++ b/src/controllers/rest/impl/FileUploadController.ts
@@ -87,11 +87,6 @@ export class FileUploadController extends BaseRestController {
             );
         } catch (e) {
             this.logger.error(e.message);
-            if (file) {
-                // this will delete files if something goes wrong, but not urls...
-                // TODO: fix
-                await FileUtils.deleteFile(file, true);
-            }
             throw e;
         }
         if (alreadyExists) {


### PR DESCRIPTION
Remove the now redundant file cleanup in the catch block of the File Upload controller.