### PR TITLE
Update CSS to fix sdk button issues on small screen

### DIFF
--- a/src/public/assets/custom/css/index.css
+++ b/src/public/assets/custom/css/index.css
@@ -111,8 +111,11 @@
     #victorique {
         display: none;
     }
-    #phpSdxButton{
+    .sdkButton {
         width: 100% !important;
+    }
+    #sdkWrapper > div.row {
+        margin-bottom: 0 !important;
     }
 }
 

--- a/src/public/index.ejs
+++ b/src/public/index.ejs
@@ -159,7 +159,7 @@
 
         <div class="row align-items-md-stretch mb-4">
             <div class="col-md-12">
-                <div class="h-100 p-5 text-bg-dark rounded-3 border border-warning-subtle bg-body-tertiary">
+                <div id="sdkWrapper" class="h-100 p-5 text-bg-dark rounded-3 border border-warning-subtle bg-body-tertiary">
                     <h2 class="mb-4 text-center">Bespoke SDKs</h2>
                     <h6 class="text-center mb-4">Official SDKs for interacting with waifuvault</h6>
                     <div class="row align-items-md-stretch mb-4">
@@ -229,7 +229,7 @@
                                     <p class="card-text">
                                         The official Rust SDK
                                     </p>
-                                    <a class="btn btn-primary btn-sm w-25" href="https://crates.io/crates/waifuvault" target="_blank">Rust SDK</a>
+                                    <a class="btn btn-primary btn-sm w-25 sdkButton" href="https://crates.io/crates/waifuvault" target="_blank">Rust SDK</a>
                                 </div>
                             </div>
                         </div>
@@ -241,7 +241,7 @@
                                     <p class="card-text">
                                         The official PHP SDK
                                     </p>
-                                        <a class="btn btn-primary btn-sm w-25" id="phpSdxButton" href="https://packagist.org/packages/ernestmarcinko/waifuvault-php-api" target="_blank">PHP SDK</a>
+                                        <a class="btn btn-primary btn-sm w-25 sdkButton" href="https://packagist.org/packages/ernestmarcinko/waifuvault-php-api" target="_blank">PHP SDK</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Update the CSS with a class for sdkButtons, and the wrapper to fix mobile buttons after the media breakpoint.