### PR TITLE
Fix handling of undefined secret

### DIFF
--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -281,9 +281,7 @@ export class FileService {
         }
         value = ObjectUtils.convertToMilli(value, timeFactor);
         const maxExp: number | null =
-            this.secret === secretToken && secretToken !== undefined
-                ? null
-                : FileUtils.getTimeLeftBySize(entry.fileSize());
+            this.secret && this.secret === secretToken ? null : FileUtils.getTimeLeftBySize(entry.fileSize());
 
         if (maxExp !== null && value > maxExp) {
             throw new BadRequest(`Cannot extend time remaining beyond ${ObjectUtils.timeToHuman(maxExp)}`);

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -281,7 +281,9 @@ export class FileService {
         }
         value = ObjectUtils.convertToMilli(value, timeFactor);
         const maxExp: number | null =
-            this.secret === secretToken ? null : FileUtils.getTimeLeftBySize(entry.fileSize());
+            this.secret === secretToken && secretToken !== undefined
+                ? null
+                : FileUtils.getTimeLeftBySize(entry.fileSize());
 
         if (maxExp !== null && value > maxExp) {
             throw new BadRequest(`Cannot extend time remaining beyond ${ObjectUtils.timeToHuman(maxExp)}`);


### PR DESCRIPTION
If the secret is undefined in the env, then ANY custom retention value can be set.

This fixes the problem.

![Screen Shot 2024-04-13 at 9 05 34 AM](https://github.com/waifuvault/WaifuVault/assets/133156975/403b0e6c-7bd6-4495-8c8a-60cf7e6eaa06)
