### PR TITLE
Check first 1kb of unidentified upload for text, set text/plain if so

### DIFF
--- a/src/public/secure/files.ejs
+++ b/src/public/secure/files.ejs
@@ -283,7 +283,7 @@
                         return;
                     }
 
-                    if (file && banned_mime_type && banned_mime_type.indexOf(file.type) !== -1) {
+                    if (file && file.type!=="" && banned_mime_type && banned_mime_type.indexOf(file.type) !== -1) {
                         Site.showError(`File is a banned type (server bans ${banned_mime_type})`);
                         uploadButton.disabled = false;
                         return;

--- a/src/services/MimeService.ts
+++ b/src/services/MimeService.ts
@@ -9,7 +9,7 @@ export class MimeService {
     @Constant(GlobalEnv.BLOCKED_MIME_TYPES)
     private readonly blockedMimeTypes: string;
 
-    public async readFirstKB(filePath: string): Promise<Buffer> {
+    private async readFirstKB(filePath: string): Promise<Buffer> {
         const fileHandle = await fs.open(filePath, "r");
         const buff = Buffer.alloc(1024);
         try {

--- a/src/services/MimeService.ts
+++ b/src/services/MimeService.ts
@@ -2,11 +2,23 @@ import { Constant, Service } from "@tsed/di";
 import mime from "mime";
 import GlobalEnv from "../model/constants/GlobalEnv.js";
 import { fileTypeFromBuffer, fileTypeFromFile } from "file-type";
+import fs from "node:fs/promises";
 
 @Service()
 export class MimeService {
     @Constant(GlobalEnv.BLOCKED_MIME_TYPES)
     private readonly blockedMimeTypes: string;
+
+    public async readFirstKB(filePath: string): Promise<Buffer> {
+        const fileHandle = await fs.open(filePath, "r");
+        const buff = Buffer.alloc(1024);
+        try {
+            await fileHandle.read(buff, 0, 1024, 0);
+        } finally {
+            await fileHandle.close();
+        }
+        return buff;
+    }
 
     public async isBlocked(filepath: string): Promise<boolean> {
         if (!this.blockedMimeTypes) {
@@ -26,7 +38,14 @@ export class MimeService {
             return mimeFromBuffer.mime;
         }
         if (resourceName) {
-            return mime.getType(resourceName);
+            const extType = mime.getType(resourceName);
+            if (extType) {
+                return extType;
+            }
+        }
+        const isText = !buff.toString("utf-8", 0, 1024).includes("\uFFFD");
+        if (isText) {
+            return "text/plain";
         }
         return null;
     }
@@ -40,6 +59,15 @@ export class MimeService {
         } catch {
             return null;
         }
-        return mime.getType(filepath);
+        const extType = mime.getType(filepath);
+        if (extType) {
+            return extType;
+        }
+        const firstKb = await this.readFirstKB(filepath);
+        const isText = !firstKb.toString("utf-8", 0, 1024).includes("\uFFFD");
+        if (isText) {
+            return "text/plain";
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Check first 1kb of unidentified upload for text, set text/plain if so.  Tested .cs, .py and .bollocks as binary and text.

![Screen Shot 2024-09-14 at 11 02 13 PM](https://github.com/user-attachments/assets/7d6ca6a9-6c59-475f-a0c5-aefa59a34e3e)

![Screen Shot 2024-09-14 at 11 07 07 PM](https://github.com/user-attachments/assets/c85aceca-d347-40ae-98fb-503feef95fcc)
