### PR TITLE
allow audio and video to be chunked enabling seeking and streaming

### DIFF
--- a/src/controllers/serve/FileServerController.ts
+++ b/src/controllers/serve/FileServerController.ts
@@ -8,6 +8,7 @@ import { FileUploadModel } from "../../model/db/FileUpload.model.js";
 import { FileService } from "../../services/FileService.js";
 import { FileUploadService } from "../../services/FileUploadService.js";
 import { EntryEncryptionWrapper } from "../../model/rest/EntryEncryptionWrapper.js";
+import { StatusCodes } from "http-status-codes";
 
 @Hidden()
 @Controller("/")
@@ -67,7 +68,7 @@ export class FileServerController {
             "Content-Length": contentLength,
             "Content-Type": contentType,
         };
-        res.writeHead(206, headers);
+        res.writeHead(StatusCodes.PARTIAL_CONTENT, headers);
         const videoStream = await entryWrapper.getStream(undefined, { start, end });
         videoStream.pipe(res);
     }

--- a/src/controllers/serve/FileServerController.ts
+++ b/src/controllers/serve/FileServerController.ts
@@ -47,8 +47,10 @@ export class FileServerController {
             return;
         }
         res.on("finish", () => this.postProcess(entryWrapper.entry));
-        res.appendHeader("Content-Length", entryWrapper.entry.fileSize.toString());
-        return entryWrapper.getStream(password);
+        if (this.allowedChunkMimeTypes.some(substr => mime.startsWith(substr))) {
+            return entryWrapper.getStream(password);
+        }
+        return entryWrapper.getBuffer(password);
     }
 
     private async chunkData(

--- a/src/model/rest/EntryEncryptionWrapper.ts
+++ b/src/model/rest/EntryEncryptionWrapper.ts
@@ -1,0 +1,24 @@
+import { FileUploadModel } from "../db/FileUpload.model.js";
+import { AutoInjectable, Inject } from "@tsed/di";
+import { EncryptionService } from "../../services/EncryptionService.js";
+import { createReadStream, ReadStream } from "node:fs";
+import { FileUtils } from "../../utils/Utils.js";
+
+@AutoInjectable()
+export class EntryEncryptionWrapper {
+    public constructor(
+        public entry: FileUploadModel,
+        @Inject() private encryptionService?: EncryptionService,
+    ) {}
+
+    public async getStream(password?: string, opts?: { start?: number; end?: number }): Promise<ReadStream> {
+        if (this.entry.encrypted) {
+            if (!password) {
+                throw new Error("Password is required to decrypt file");
+            }
+            const b = await this.encryptionService!.decrypt(this.entry, password);
+            return ReadStream.from(b) as ReadStream;
+        }
+        return createReadStream(FileUtils.getFilePath(this.entry), opts);
+    }
+}

--- a/src/model/rest/EntryEncryptionWrapper.ts
+++ b/src/model/rest/EntryEncryptionWrapper.ts
@@ -3,6 +3,7 @@ import { AutoInjectable, Inject } from "@tsed/di";
 import { EncryptionService } from "../../services/EncryptionService.js";
 import { createReadStream, ReadStream } from "node:fs";
 import { FileUtils } from "../../utils/Utils.js";
+import fs from "node:fs/promises";
 
 @AutoInjectable()
 export class EntryEncryptionWrapper {
@@ -13,12 +14,25 @@ export class EntryEncryptionWrapper {
 
     public async getStream(password?: string, opts?: { start?: number; end?: number }): Promise<ReadStream> {
         if (this.entry.encrypted) {
-            if (!password) {
-                throw new Error("Password is required to decrypt file");
-            }
-            const b = await this.encryptionService!.decrypt(this.entry, password);
+            const b = await this.encryptionService!.decrypt(this.entry, password!);
             return ReadStream.from(b) as ReadStream;
         }
         return createReadStream(FileUtils.getFilePath(this.entry), opts);
+    }
+
+    public getBuffer(password?: string): Promise<Buffer> {
+        if (this.entry.encrypted) {
+            this.checkPassword(password);
+            return this.encryptionService!.decrypt(this.entry, password!);
+        }
+        return fs.readFile(FileUtils.getFilePath(this.entry));
+    }
+
+    private checkPassword(password?: string): void {
+        if (this.entry.encrypted) {
+            if (!password) {
+                throw new Error("Password is required to decrypt file");
+            }
+        }
     }
 }

--- a/src/public/secure/files.ejs
+++ b/src/public/secure/files.ejs
@@ -331,7 +331,7 @@
                     xhr.onload = function() {
                         const response =  JSON.parse(xhr.response);
                         if (xhr.status === 200 || xhr.status === 201) {
-                            const url = response.url;
+                            const url = encodeURI(response.url);
                             const btn = document.createElement("button");
                             btn.className = "btn btn-sm btn-outline-primary mt-3 d-block";
                             btn.addEventListener("click", () => navigator.clipboard.writeText(url));
@@ -390,7 +390,7 @@
                             data = `<span>${data}</span>`;
                         }
                         if (copyButtons.includes(header)) {
-                            data += `<i title="Copy value to clipboard" class='bi bi-clipboard ms-1' onclick='navigator.clipboard.writeText("${details[1]}");'></i>`;
+                            data += `<i title="Copy value to clipboard" class='bi bi-clipboard ms-1' onclick='navigator.clipboard.writeText("${encodeURI(details[1])}");'></i>`;
                         }
                         return `<tr><th>${header}</th><td>${data}</td></tr>`;
                     }).join("");

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -9,7 +9,7 @@ import GlobalEnv from "../model/constants/GlobalEnv.js";
 import { promisify } from "node:util";
 import { FileUtils } from "../utils/Utils.js";
 import { Forbidden } from "@tsed/exceptions";
-import { fileTypeStream, ReadableStreamWithFileType } from "file-type";
+import { buffer as toBuff } from "node:stream/consumers";
 
 @Service()
 export class EncryptionService implements OnInit {
@@ -28,7 +28,7 @@ export class EncryptionService implements OnInit {
         });
     }
 
-    public async encrypt(file: string | Buffer, password: string): Promise<Buffer | null> {
+    public async encrypt(file: string | Buffer | ReadStream, password: string): Promise<Buffer | null> {
         if (!this.salt) {
             return null;
         }
@@ -36,8 +36,10 @@ export class EncryptionService implements OnInit {
         if (typeof file === "string") {
             const fileSource = FileUtils.getFilePath(Path.basename(file));
             buffer = await fs.readFile(fileSource);
-        } else {
+        } else if (file instanceof Buffer) {
             buffer = file;
+        } else {
+            buffer = await toBuff(file as ReadStream);
         }
         const iv = await this.randomBytes(16);
         const key = await this.getKey(password);
@@ -49,44 +51,13 @@ export class EncryptionService implements OnInit {
         return encryptedBuffer;
     }
 
-    /* public async decrypt(source: FileUploadModel, password?: string): Promise<Buffer> {
-        const fileSource = FileUtils.getFilePath(source);
-        const fileBuffer = await fs.readFile(fileSource);
-        const isEncrypted = source.encrypted;
-        if (!source.settings?.password) {
-            // no password, thus not encrypted, just return buffer
-            return fileBuffer;
-        }
-        if (!password) {
-            throw new Forbidden(`${isEncrypted ? "Encrypted" : "Protected"} file requires a password`);
-        }
-        const passwordMatches = await this.validatePassword(source, password);
-        if (!passwordMatches) {
-            throw new Forbidden("Password is incorrect");
-        }
-        if (!isEncrypted) {
-            // the file is password protected, but not encrypted, so return it
-            return fileBuffer;
-        }
-        // we can now assume the password is valid
-        const encrypted = fileBuffer;
-        const iv = encrypted.subarray(0, 16);
-        const encryptedRest = encrypted.subarray(16);
-        const key = await this.getKey(password);
-        const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
-        return Buffer.concat([decipher.update(encryptedRest), decipher.final()]);
-    }*/
-
-    public async decrypt(source: FileUploadModel, password?: string): Promise<ReadableStreamWithFileType> {
+    public async decrypt(source: FileUploadModel, password?: string): Promise<ReadStream> {
         const fileSource = FileUtils.getFilePath(source);
         const isEncrypted = source.encrypted;
 
         if (!source.settings?.password) {
             // no password, thus not encrypted, just return file stream
-            const s = createReadStream(fileSource);
-            // const mime = createReadStream(fileSource);
-            // const mimeRes = await fileTypeFromStream(mime);
-            return fileTypeStream(s);
+            return createReadStream(fileSource);
         }
 
         if (!password) {
@@ -100,10 +71,7 @@ export class EncryptionService implements OnInit {
 
         if (!isEncrypted) {
             // the file is password protected, but not encrypted, so return it
-            const s = createReadStream(fileSource);
-            // const mime = createReadStream(fileSource);
-            // const mimeRes = await fileTypeFromStream(mime);
-            return fileTypeStream(s);
+            return createReadStream(fileSource);
         }
 
         const encrypted = await fs.readFile(fileSource);
@@ -112,18 +80,17 @@ export class EncryptionService implements OnInit {
         const key = await this.getKey(password);
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         const b = Buffer.concat([decipher.update(encryptedRest), decipher.final()]);
-        return fileTypeStream(ReadStream.from(b));
-        // return [ReadStream.from(b) as ReadStream, null];
+        return ReadStream.from(b) as ReadStream;
     }
 
-    // public async changePassword(oldPassword: string, newPassword: string, entry: FileUploadModel): Promise<void> {
-    //     const decryptedBuffer = await this.decrypt(entry, oldPassword);
-    //     const newBuffer = await this.encrypt(decryptedBuffer, newPassword);
-    //     if (!newBuffer) {
-    //         throw new Error("Unable to encrypt file");
-    //     }
-    //     await fs.writeFile(FileUtils.getFilePath(entry), newBuffer);
-    // }
+    public async changePassword(oldPassword: string, newPassword: string, entry: FileUploadModel): Promise<void> {
+        const decryptedBuffer = await this.decrypt(entry, oldPassword);
+        const newBuffer = await this.encrypt(decryptedBuffer, newPassword);
+        if (!newBuffer) {
+            throw new Error("Unable to encrypt file");
+        }
+        await fs.writeFile(FileUtils.getFilePath(entry), newBuffer);
+    }
 
     private validatePassword(resource: FileUploadModel, password: string): Promise<boolean> {
         return argon2.verify(resource.settings!.password!, password);

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -49,27 +49,6 @@ export class EncryptionService implements OnInit {
 
     public async decrypt(source: FileUploadModel, password: string): Promise<Buffer> {
         const fileSource = FileUtils.getFilePath(source);
-        /* const isEncrypted = source.encrypted;
-
-        if (!source.settings?.password) {
-            // no password, thus not encrypted, just return file stream
-            return createReadStream(fileSource);
-        }
-
-        if (!password) {
-            throw new Forbidden(`${isEncrypted ? "Encrypted" : "Protected"} file requires a password`);
-        }
-
-        const passwordMatches = await this.validatePassword(source, password);
-        if (!passwordMatches) {
-            throw new Forbidden("Password is incorrect");
-        }
-
-        if (!isEncrypted) {
-            // the file is password protected, but not encrypted, so return it
-            return createReadStream(fileSource);
-        }*/
-
         const passwordMatches = await this.validatePassword(source, password);
         if (!passwordMatches) {
             throw new Forbidden("Password is incorrect");

--- a/src/services/EncryptionService.ts
+++ b/src/services/EncryptionService.ts
@@ -1,13 +1,15 @@
 import { Constant, OnInit, Service } from "@tsed/di";
 import { FileUploadModel } from "../model/db/FileUpload.model.js";
-import fs from "node:fs/promises";
-import crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import { createReadStream, ReadStream } from "node:fs";
+import * as crypto from "node:crypto";
 import argon2 from "argon2";
-import { Forbidden } from "@tsed/exceptions";
 import Path from "node:path";
 import GlobalEnv from "../model/constants/GlobalEnv.js";
 import { promisify } from "node:util";
 import { FileUtils } from "../utils/Utils.js";
+import { Forbidden } from "@tsed/exceptions";
+import { fileTypeStream, ReadableStreamWithFileType } from "file-type";
 
 @Service()
 export class EncryptionService implements OnInit {
@@ -47,7 +49,7 @@ export class EncryptionService implements OnInit {
         return encryptedBuffer;
     }
 
-    public async decrypt(source: FileUploadModel, password?: string): Promise<Buffer> {
+    /* public async decrypt(source: FileUploadModel, password?: string): Promise<Buffer> {
         const fileSource = FileUtils.getFilePath(source);
         const fileBuffer = await fs.readFile(fileSource);
         const isEncrypted = source.encrypted;
@@ -73,16 +75,55 @@ export class EncryptionService implements OnInit {
         const key = await this.getKey(password);
         const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
         return Buffer.concat([decipher.update(encryptedRest), decipher.final()]);
+    }*/
+
+    public async decrypt(source: FileUploadModel, password?: string): Promise<ReadableStreamWithFileType> {
+        const fileSource = FileUtils.getFilePath(source);
+        const isEncrypted = source.encrypted;
+
+        if (!source.settings?.password) {
+            // no password, thus not encrypted, just return file stream
+            const s = createReadStream(fileSource);
+            // const mime = createReadStream(fileSource);
+            // const mimeRes = await fileTypeFromStream(mime);
+            return fileTypeStream(s);
+        }
+
+        if (!password) {
+            throw new Forbidden(`${isEncrypted ? "Encrypted" : "Protected"} file requires a password`);
+        }
+
+        const passwordMatches = await this.validatePassword(source, password);
+        if (!passwordMatches) {
+            throw new Forbidden("Password is incorrect");
+        }
+
+        if (!isEncrypted) {
+            // the file is password protected, but not encrypted, so return it
+            const s = createReadStream(fileSource);
+            // const mime = createReadStream(fileSource);
+            // const mimeRes = await fileTypeFromStream(mime);
+            return fileTypeStream(s);
+        }
+
+        const encrypted = await fs.readFile(fileSource);
+        const iv = encrypted.subarray(0, 16);
+        const encryptedRest = encrypted.subarray(16);
+        const key = await this.getKey(password);
+        const decipher = crypto.createDecipheriv(this.algorithm, key, iv);
+        const b = Buffer.concat([decipher.update(encryptedRest), decipher.final()]);
+        return fileTypeStream(ReadStream.from(b));
+        // return [ReadStream.from(b) as ReadStream, null];
     }
 
-    public async changePassword(oldPassword: string, newPassword: string, entry: FileUploadModel): Promise<void> {
-        const decryptedBuffer = await this.decrypt(entry, oldPassword);
-        const newBuffer = await this.encrypt(decryptedBuffer, newPassword);
-        if (!newBuffer) {
-            throw new Error("Unable to encrypt file");
-        }
-        await fs.writeFile(FileUtils.getFilePath(entry), newBuffer);
-    }
+    // public async changePassword(oldPassword: string, newPassword: string, entry: FileUploadModel): Promise<void> {
+    //     const decryptedBuffer = await this.decrypt(entry, oldPassword);
+    //     const newBuffer = await this.encrypt(decryptedBuffer, newPassword);
+    //     if (!newBuffer) {
+    //         throw new Error("Unable to encrypt file");
+    //     }
+    //     await fs.writeFile(FileUtils.getFilePath(entry), newBuffer);
+    // }
 
     private validatePassword(resource: FileUploadModel, password: string): Promise<boolean> {
         return argon2.verify(resource.settings!.password!, password);

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -8,7 +8,7 @@ import { FileUtils } from "../utils/Utils.js";
 import { FileUploadModel } from "../model/db/FileUpload.model.js";
 import { FileUploadResponseDto } from "../model/dto/FileUploadResponseDto.js";
 import { BadRequest, NotFound } from "@tsed/exceptions";
-import { ReadableStreamWithFileType } from "file-type";
+import { ReadStream } from "node:fs";
 
 /**
  * Class that deals with interacting files from the filesystem
@@ -53,7 +53,7 @@ export class FileService {
         fileNameOnSystem: string,
         requestedFileName?: string,
         password?: string,
-    ): Promise<[ReadableStreamWithFileType, FileUploadModel]> {
+    ): Promise<[ReadStream, FileUploadModel]> {
         const entry = await this.repo.getEntryFileName(fileNameOnSystem);
         const resource = requestedFileName ?? fileNameOnSystem;
         if (entry === null) {

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -8,6 +8,7 @@ import { FileUtils } from "../utils/Utils.js";
 import { FileUploadModel } from "../model/db/FileUpload.model.js";
 import { FileUploadResponseDto } from "../model/dto/FileUploadResponseDto.js";
 import { BadRequest, NotFound } from "@tsed/exceptions";
+import { ReadableStreamWithFileType } from "file-type";
 
 /**
  * Class that deals with interacting files from the filesystem
@@ -52,7 +53,7 @@ export class FileService {
         fileNameOnSystem: string,
         requestedFileName?: string,
         password?: string,
-    ): Promise<[Buffer, FileUploadModel]> {
+    ): Promise<[ReadableStreamWithFileType, FileUploadModel]> {
         const entry = await this.repo.getEntryFileName(fileNameOnSystem);
         const resource = requestedFileName ?? fileNameOnSystem;
         if (entry === null) {

--- a/src/services/FileUploadService.ts
+++ b/src/services/FileUploadService.ts
@@ -223,7 +223,7 @@ export class FileUploadService {
                 if (!dto.previousPassword) {
                     throw new BadRequest("You must supply 'previousPassword' to change the password");
                 }
-                // await this.encryptionService.changePassword(dto.previousPassword, dto.password, entryToModify);
+                await this.encryptionService.changePassword(dto.previousPassword, dto.password, entryToModify);
             } else {
                 const didEncrypt = await this.encryptionService.encrypt(
                     FileUtils.getFilePath(entryToModify),

--- a/src/services/FileUploadService.ts
+++ b/src/services/FileUploadService.ts
@@ -223,7 +223,7 @@ export class FileUploadService {
                 if (!dto.previousPassword) {
                     throw new BadRequest("You must supply 'previousPassword' to change the password");
                 }
-                await this.encryptionService.changePassword(dto.previousPassword, dto.password, entryToModify);
+                // await this.encryptionService.changePassword(dto.previousPassword, dto.password, entryToModify);
             } else {
                 const didEncrypt = await this.encryptionService.encrypt(
                     FileUtils.getFilePath(entryToModify),

--- a/src/services/MimeService.ts
+++ b/src/services/MimeService.ts
@@ -1,8 +1,9 @@
 import { Constant, Service } from "@tsed/di";
 import mime from "mime";
 import GlobalEnv from "../model/constants/GlobalEnv.js";
-import { fileTypeFromBuffer, fileTypeFromFile } from "file-type";
+import { fileTypeFromBuffer, fileTypeFromFile, fileTypeFromStream } from "file-type";
 import fs from "node:fs/promises";
+import { ReadStream } from "node:fs";
 
 @Service()
 export class MimeService {
@@ -53,6 +54,31 @@ export class MimeService {
         if (this.isText(buff)) {
             return "text/plain";
         }
+
+        return null;
+    }
+
+    public async findMimeTypeFromStream(buff: ReadStream, resourceName?: string): Promise<string | null> {
+        // the order is very important, do not change
+
+        // first check the buffer magic bytes
+        const mimeFromBuffer = await fileTypeFromStream(buff);
+        if (mimeFromBuffer) {
+            return mimeFromBuffer.mime;
+        }
+
+        // then check the extension
+        if (resourceName) {
+            const extType = mime.getType(resourceName);
+            if (extType) {
+                return extType;
+            }
+        }
+
+        // if there still is no mapping, see if the file is plain text
+        // if (this.isText(buff)) {
+        //     return "text/plain";
+        // }
 
         return null;
     }

--- a/src/services/MimeService.ts
+++ b/src/services/MimeService.ts
@@ -1,9 +1,8 @@
 import { Constant, Service } from "@tsed/di";
 import mime from "mime";
 import GlobalEnv from "../model/constants/GlobalEnv.js";
-import { fileTypeFromBuffer, fileTypeFromFile, fileTypeFromStream } from "file-type";
+import { fileTypeFromFile } from "file-type";
 import fs from "node:fs/promises";
-import { ReadStream } from "node:fs";
 
 @Service()
 export class MimeService {
@@ -31,56 +30,6 @@ export class MimeService {
             return false;
         }
         return this.blockedMimeTypes.split(",").includes(detected);
-    }
-
-    public async findMimeTypeFromBuffer(buff: Buffer, resourceName?: string): Promise<string | null> {
-        // the order is very important, do not change
-
-        // first check the buffer magic bytes
-        const mimeFromBuffer = await fileTypeFromBuffer(buff);
-        if (mimeFromBuffer) {
-            return mimeFromBuffer.mime;
-        }
-
-        // then check the extension
-        if (resourceName) {
-            const extType = mime.getType(resourceName);
-            if (extType) {
-                return extType;
-            }
-        }
-
-        // if there still is no mapping, see if the file is plain text
-        if (this.isText(buff)) {
-            return "text/plain";
-        }
-
-        return null;
-    }
-
-    public async findMimeTypeFromStream(buff: ReadStream, resourceName?: string): Promise<string | null> {
-        // the order is very important, do not change
-
-        // first check the buffer magic bytes
-        const mimeFromBuffer = await fileTypeFromStream(buff);
-        if (mimeFromBuffer) {
-            return mimeFromBuffer.mime;
-        }
-
-        // then check the extension
-        if (resourceName) {
-            const extType = mime.getType(resourceName);
-            if (extType) {
-                return extType;
-            }
-        }
-
-        // if there still is no mapping, see if the file is plain text
-        // if (this.isText(buff)) {
-        //     return "text/plain";
-        // }
-
-        return null;
     }
 
     public async findMimeType(filepath: string): Promise<string | null> {


### PR DESCRIPTION
videos and audio are now chucked and streamed to the client at 1mb/chunk, this solves the issue of the client dying sometimes when a video file is requested and the broken seeking. this will not work for encrypted files or it would mean the file would need to be decrpyted every time a chunk is requested