### PR TITLE
remove deprecated code

### DIFF
--- a/src/model/rest/EntryEncryptionWrapper.ts
+++ b/src/model/rest/EntryEncryptionWrapper.ts
@@ -14,6 +14,7 @@ export class EntryEncryptionWrapper {
 
     public async getStream(password?: string, opts?: { start?: number; end?: number }): Promise<ReadStream> {
         if (this.entry.encrypted) {
+            this.checkPassword(password);
             const b = await this.encryptionService!.decrypt(this.entry, password!);
             return ReadStream.from(b) as ReadStream;
         }


### PR DESCRIPTION
`registerProvider` was depricated in tsed 8, the new injectable function is used to register it using an async factory