### PR TITLE
simplify spawning threads

### DIFF
--- a/src/services/AlbumService.ts
+++ b/src/services/AlbumService.ts
@@ -189,7 +189,7 @@ export class AlbumService {
         }
         this.checkPrivateToken(privateAlbumToken, album);
 
-        const [workerPromise] = WorkerUtils.newWorker<string>("generateThumbnails.js", {
+        const [workerPromise] = WorkerUtils.newWorker("generateThumbnails.js", {
             privateAlbumToken: privateAlbumToken,
             filesIds,
         });

--- a/src/services/AlbumService.ts
+++ b/src/services/AlbumService.ts
@@ -14,7 +14,6 @@ import fs, { ReadStream } from "node:fs";
 import GlobalEnv from "../model/constants/GlobalEnv.js";
 import { MimeService } from "./MimeService.js";
 import { Logger } from "@tsed/logger";
-import { Worker } from "node:worker_threads";
 
 @Service()
 export class AlbumService {
@@ -190,14 +189,11 @@ export class AlbumService {
         }
         this.checkPrivateToken(privateAlbumToken, album);
 
-        const worker = new Worker(new URL("../workers/generateThumbnails.js", import.meta.url), {
-            workerData: {
-                privateAlbumToken: privateAlbumToken,
-                filesIds,
-            },
+        const [workerPromise] = WorkerUtils.newWorker<string>("generateThumbnails.js", {
+            privateAlbumToken: privateAlbumToken,
+            filesIds,
         });
 
-        const workerPromise = WorkerUtils.newWorkerPromise(worker);
         workerPromise
             .then(() => this.logger.info(`Successfully generated thumbnails for album ${privateAlbumToken}`))
             .catch(e => this.logger.error(e));
@@ -277,14 +273,13 @@ export class AlbumService {
                 parsedFileName: file.parsedFileName,
             };
         });
-        const worker = new Worker(new URL("../workers/zipFiles.js", import.meta.url), {
-            workerData: {
+
+        const [zipLocation] = await Promise.all(
+            WorkerUtils.newWorker<string>("zipFiles.js", {
                 filesToZip: workerData,
                 albumName: album.name,
-            },
-        });
-
-        const zipLocation = await WorkerUtils.newWorkerPromise<string>(worker);
+            }),
+        );
 
         return [fs.createReadStream(zipLocation), album.name, zipLocation];
     }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -224,8 +224,16 @@ export class NetworkUtils {
 }
 
 export class WorkerUtils {
-    public static newWorkerPromise<T = void>(worker: Worker): Promise<T> {
-        return new Promise((resolve, reject): void => {
+    public static newWorker<T = void>(file: string | URL, data: Record<string, unknown>): [Promise<T>, Worker] {
+        if (typeof file === "string") {
+            // if string, the file ust be relative to the `workers` folder
+            file = new URL(`../workers/${file}`, import.meta.url);
+        }
+        const worker = new Worker(file, {
+            workerData: data,
+        });
+
+        const p: Promise<T> = new Promise((resolve, reject): void => {
             worker.on("message", (message: WorkerResponse<T>) => {
                 if (message.success) {
                     resolve(message.data);
@@ -240,6 +248,8 @@ export class WorkerUtils {
                 }
             });
         });
+
+        return [p, worker];
     }
 }
 


### PR DESCRIPTION
worker threads could be used a lot more in the future, and because of such things, i have made spawning threads a lot easier by calling one method that will return the worker and a promise that will resolve to the value that the worker will produce.

if you pass a file as a string to the util function, it assumes that it will be relative to `src/workers`