### PR TITLE
Fix redis looping if started as 'static' and redis is not running

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -284,6 +284,13 @@ async function initRedis(options: Partial<TsED.Configuration>): Promise<void> {
 
         await Promise.all([pubClient.connect(), subClient.connect()]);
         opts.socketIO!.adapter = createShardedAdapter(pubClient, subClient);
+    } else {
+        // Non dynamic must still test connection
+        const pubClient = createClient({
+            url: process.env.REDIS_URI as string,
+        });
+        await pubClient.connect();
+        await pubClient.quit();
     }
 
     options["ioredis"] = [


### PR DESCRIPTION
If started with HOME_PAGE_FILE_COUNTER set to other than 'dynamic' and redis is not running, application will loop trying to connect to redis instead of failing.

This fixes that.