### PR TITLE
Add fix for UTF8 filename issue with the Express Multer

### DIFF
--- a/src/services/FileUploadService.ts
+++ b/src/services/FileUploadService.ts
@@ -159,7 +159,7 @@ export class FileUploadService {
             originalFileName = originalFileNameRes;
         } else {
             resourcePath = source.path;
-            originalFileName = source.originalname;
+            originalFileName = Buffer.from(source.originalname, "latin1").toString("utf8");
         }
         if (originalFileName.startsWith("/")) {
             originalFileName = originalFileName.substring(1);


### PR DESCRIPTION
The express multer does not properly handle UTF-8 filenames. 

Ref: https://github.com/expressjs/multer/issues/1104

Adjusted the code which gets the file name with the workaround suggested.

UTF-8 filenames work now.