### PR TITLE
Make getAlbum return only private token matches by default, with an optional boolean to return public matches too

### DIFF
--- a/src/controllers/rest/impl/AlbumController.ts
+++ b/src/controllers/rest/impl/AlbumController.ts
@@ -179,7 +179,7 @@ export class AlbumController extends BaseRestController {
         @PathParams("albumToken")
         albumToken: string,
     ): Promise<AlbumModel> {
-        const album = await this.albumService.getAlbum(albumToken);
+        const album = await this.albumService.getAlbum(albumToken, true, true);
         if (!album.isShared) {
             throw new BadRequest("This album is not public");
         }

--- a/src/controllers/views/HomeView.ts
+++ b/src/controllers/views/HomeView.ts
@@ -61,7 +61,7 @@ export class HomeView extends BaseViewController {
         if (!albumExists) {
             throw new NotFound("Album does not exist");
         }
-        const album = await this.albumService.getAlbum(publicToken);
+        const album = await this.albumService.getAlbum(publicToken, true, true);
         const dto = PublicAlbumDto.fromModel(album);
         const thumbs = dto.files.filter(f => f.metadata.thumbnail).map(x => x.metadata.thumbnail ?? "");
         const chosenThumb = thumbs.length > 0 ? Math.floor(Math.random() * thumbs.length) : 0;

--- a/src/db/dao/AlbumDao.ts
+++ b/src/db/dao/AlbumDao.ts
@@ -22,7 +22,32 @@ export class AlbumDao extends AbstractTypeOrmDao<AlbumModel> {
         return deleteResult.affected === 1;
     }
 
-    public getAlbum(token: string, includeFiles = true, transaction?: EntityManager): Promise<AlbumModel | null> {
+    public getAlbum(
+        token: string,
+        includeFiles = true,
+        allowPublic = false,
+        transaction?: EntityManager,
+    ): Promise<AlbumModel | null> {
+        if (allowPublic) {
+            return this.getRepository(transaction).findOne({
+                relations: includeFiles ? ["files"] : undefined,
+                order: includeFiles
+                    ? {
+                          files: {
+                              addedToAlbumOrder: "ASC",
+                          },
+                      }
+                    : undefined,
+                where: [
+                    {
+                        albumToken: token,
+                    },
+                    {
+                        publicToken: token,
+                    },
+                ],
+            });
+        }
         return this.getRepository(transaction).findOne({
             relations: includeFiles ? ["files"] : undefined,
             order: includeFiles
@@ -35,9 +60,6 @@ export class AlbumDao extends AbstractTypeOrmDao<AlbumModel> {
             where: [
                 {
                     albumToken: token,
-                },
-                {
-                    publicToken: token,
                 },
             ],
         });

--- a/src/db/repo/AlbumRepo.ts
+++ b/src/db/repo/AlbumRepo.ts
@@ -24,7 +24,7 @@ export class AlbumRepo {
     public async deleteAlbum(albumToken: string, deleteFiles = false): Promise<boolean> {
         if (deleteFiles) {
             return this.albumDao.dataSource.transaction(async entityManager => {
-                const album = await this.albumDao.getAlbum(albumToken, true, entityManager);
+                const album = await this.albumDao.getAlbum(albumToken, true, false, entityManager);
                 if (album?.files) {
                     const files = album.files;
                     await this.fileRepo.clearCache(files.map(f => f.token));
@@ -35,7 +35,7 @@ export class AlbumRepo {
             });
         }
         const [res, files] = await this.albumDao.dataSource.transaction(async entityManager => {
-            const album = await this.albumDao.getAlbum(albumToken, true, entityManager);
+            const album = await this.albumDao.getAlbum(albumToken, true, false, entityManager);
             const filesRemoved: FileUploadModel[] = [];
             if (album && album.files && album.files.length > 0) {
                 filesRemoved.push(...album.files);
@@ -50,8 +50,8 @@ export class AlbumRepo {
         return res;
     }
 
-    public getAlbum(token: string, includeFiles = true): Promise<AlbumModel | null> {
-        return this.albumDao.getAlbum(token, includeFiles);
+    public getAlbum(token: string, includeFiles = true, allowPublic = false): Promise<AlbumModel | null> {
+        return this.albumDao.getAlbum(token, includeFiles, allowPublic);
     }
 
     public albumNameExists(name: string, bucketToken: string): Promise<boolean> {


### PR DESCRIPTION
Make getAlbum return only private token matches by default, with an additional optional parameter to also include public token matches.