### PR TITLE
Swaps on large albums were inefficient.  It pulled all files for every swap, which was slow for very large albums.  This simply handles the single file id given.

### DIFF
--- a/src/controllers/rest/impl/AlbumController.ts
+++ b/src/controllers/rest/impl/AlbumController.ts
@@ -125,7 +125,7 @@ export class AlbumController extends BaseRestController {
     ): Promise<PlatformResponse> {
         const success = await this.albumService.swapFileOrder(albumToken, id, oldPosition, newPosition);
         if (success) {
-            return super.doSuccess(res, "file order swap failed");
+            return super.doSuccess(res, "file order swap succeeded");
         }
         return super.doError(res, "file order swap failed", StatusCodes.INTERNAL_SERVER_ERROR);
     }

--- a/src/db/dao/FileDao.ts
+++ b/src/db/dao/FileDao.ts
@@ -259,6 +259,15 @@ export class FileDao extends AbstractTypeOrmDao<FileUploadModel> implements Afte
         });
     }
 
+    public getEntryById(id: number, transaction?: EntityManager): Promise<FileUploadModel | null> {
+        return this.getRepository(transaction).findOne({
+            where: {
+                id,
+                expires: this.expiresCondition,
+            },
+        });
+    }
+
     public async incrementViews(token: string, transaction?: EntityManager): Promise<void> {
         await this.getRepository(transaction).increment({ token }, "views", 1);
     }

--- a/src/db/repo/FileRepo.ts
+++ b/src/db/repo/FileRepo.ts
@@ -31,6 +31,10 @@ export class FileRepo {
         return this.fileDao.getEntryFileName(Path.parse(fileName).name);
     }
 
+    public getEntryById(id: number): Promise<FileUploadModel | null> {
+        return this.fileDao.getEntryById(id);
+    }
+
     public getEntriesFromChecksum(hash: string): Promise<FileUploadModel[]> {
         return this.fileDao.getEntriesFromChecksum(hash);
     }


### PR DESCRIPTION
Swap function was pulling all files in an album for every swap request.  
For large albums this is inefficient and slow.
Adjusted to handle just the single file listed in the swap.