### PR TITLE
Fix destructuring in duplicate deleter

### DIFF
--- a/src/db/dao/FileDao.ts
+++ b/src/db/dao/FileDao.ts
@@ -346,7 +346,7 @@ export class FileDao extends AbstractTypeOrmDao<FileUploadModel> implements Afte
 
         const deletedRecords: FileUploadModel[] = [];
 
-        for (const { checksum } of duplicateChecksums) {
+        for (const { file_checksum: checksum } of duplicateChecksums) {
             const recordsWithChecksum = await repository.find({
                 where: { checksum },
                 order: { id: "ASC" },


### PR DESCRIPTION
Destructure used the wrong property name, leading to undefined checksum
